### PR TITLE
(#2816) Remove duplicate xCO2 atmosphere column from exports

### DIFF
--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataReduction/UnderwayAtmosphericPco2Reducer.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataReduction/UnderwayAtmosphericPco2Reducer.java
@@ -61,7 +61,6 @@ public class UnderwayAtmosphericPco2Reducer extends DataReducer {
 
       record.put("Sea Level Pressure", seaLevelPressure);
       record.put("pH₂O", calculator.pH2O);
-      record.put("xCO₂", co2InGas);
       record.put("pCO₂", calculator.pCO2);
       record.put("fCO₂", calculator.fCO2);
     } catch (Exception e) {
@@ -81,12 +80,9 @@ public class UnderwayAtmosphericPco2Reducer extends DataReducer {
         "pH₂O", "Atmosphere Water Vapour Pressure", "CPVPZZ01", "hPa", false));
 
       calculationParameters.add(new CalculationParameter(makeParameterId(2),
-        "xCO₂", "xCO₂ In Atmosphere", "XCO2DRAT", "μmol mol⁻¹", true));
-
-      calculationParameters.add(new CalculationParameter(makeParameterId(3),
         "pCO₂", "pCO₂ In Atmosphere", "ACO2XXXX", "μatm", true));
 
-      calculationParameters.add(new CalculationParameter(makeParameterId(4),
+      calculationParameters.add(new CalculationParameter(makeParameterId(3),
         "fCO₂", "fCO₂ In Atmosphere", "FCO2WTAT", "μatm", true));
     }
 

--- a/configuration/export_config.json
+++ b/configuration/export_config.json
@@ -69,6 +69,7 @@
       "AWMXRCORR": "Atmosphere True Moisture [umol mol-1]",
       "CAPAZZ01": "Atmospheric Pressure At Sea Level [hPa]",
       "XCO2DRAT": "xCO2 in atmosphere [umol mol-1]",
+      "XCO2DCMA": "xCO2 in atmosphere [umol mol-1]",
       "LPRES0EQ_equil": "LICOR Pressure (Equilibrator) [hPa]",
       "LPRES0EQ_atm": "LICOR Pressure (Atmosphere) [hPa]",
       "CTMPZZ01": "Atmospheric Temperature [degC]"
@@ -110,6 +111,7 @@
       "AWMXRCORR": "Atmosphere True Moisture [umol mol-1]",
       "CAPAZZ01": "Atmospheric Pressure At Sea Level [hPa]",
       "XCO2DRAT": "xCO2 in atmosphere [umol mol-1]",
+      "XCO2DCMA": "xCO2 in atmosphere [umol mol-1]",
       "LPRES0EQ_equil": "LICOR Pressure (Equilibrator) [hPa]",
       "LPRES0EQ_atm": "LICOR Pressure (Atmosphere) [hPa]",
       "CTMPZZ01": "Atmospheric Temperature [degC]"


### PR DESCRIPTION
Fix #2816
