### PR TITLE
2816 Remove ₂ characters from ICOS OTC column names

### DIFF
--- a/WebApp/junit/junit/uk/ac/exeter/QuinCe/data/Dataset/DataReduction/DataReducerFactoryTest.java
+++ b/WebApp/junit/junit/uk/ac/exeter/QuinCe/data/Dataset/DataReduction/DataReducerFactoryTest.java
@@ -73,7 +73,7 @@ public class DataReducerFactoryTest extends BaseTest {
   }
 
   @ParameterizedTest
-  @CsvSource({ "true,5", "false,3" })
+  @CsvSource({ "true,4", "false,2" })
   public void getCalculationParametersWithCalcColumnsTest(
     boolean includeCalculationColumns, int expectedSize) throws Exception {
     List<CalculationParameter> params = DataReducerFactory
@@ -97,7 +97,7 @@ public class DataReducerFactoryTest extends BaseTest {
     Map<Variable, List<CalculationParameter>> params = DataReducerFactory
       .getCalculationParameters(vars);
 
-    assertEquals(5, params.get(var1).size());
+    assertEquals(4, params.get(var1).size());
     assertEquals(6, params.get(var2).size());
   }
 
@@ -150,7 +150,7 @@ public class DataReducerFactoryTest extends BaseTest {
     CalculationParameter param = DataReducerFactory
       .getVariableParameter(makeVariable(), 2);
 
-    assertEquals("xCO₂ In Atmosphere", param.getLongName());
+    assertEquals("pCO₂ In Atmosphere", param.getLongName());
   }
 
   @Test

--- a/WebApp/junit/junit/uk/ac/exeter/QuinCe/data/Dataset/DataReduction/UnderwayAtmospheric12_13Pco2ReducerTest2.java
+++ b/WebApp/junit/junit/uk/ac/exeter/QuinCe/data/Dataset/DataReduction/UnderwayAtmospheric12_13Pco2ReducerTest2.java
@@ -96,7 +96,6 @@ public class UnderwayAtmospheric12_13Pco2ReducerTest2 extends DataReducerTest {
       getDataSource().getConnection());
 
     assertEquals(0.00909D, record.getCalculationValue("pH₂O"), 0.0001);
-    assertEquals(399.274D, record.getCalculationValue("xCO₂"), 0.0001);
     assertEquals(399.71652D, record.getCalculationValue("pCO₂"), 0.0001);
     assertEquals(398.0793D, record.getCalculationValue("fCO₂"), 0.0001);
   }

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataReduction/UnderwayAtmospheric12_13Pco2Reducer.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataReduction/UnderwayAtmospheric12_13Pco2Reducer.java
@@ -69,7 +69,6 @@ public class UnderwayAtmospheric12_13Pco2Reducer
 
     // Will be the same for both 12C and 13C
     record.put("pH₂O", x12CO2Calculator.pH2O);
-    record.put("xCO₂", x12CO2 + x13CO2);
     record.put("pCO₂", x12CO2Calculator.pCO2 + x13CO2Calculator.pCO2);
     record.put("fCO₂", x12CO2Calculator.fCO2 + x13CO2Calculator.fCO2);
   }
@@ -88,7 +87,6 @@ public class UnderwayAtmospheric12_13Pco2Reducer
       seaLevelPressure, co2);
 
     record.put("pH₂O", calculator.pH2O);
-    record.put("xCO₂", co2);
     record.put("pCO₂", calculator.pCO2);
     record.put("fCO₂", calculator.fCO2);
   }

--- a/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataReduction/UnderwayAtmosphericPco2Reducer.java
+++ b/WebApp/src/uk/ac/exeter/QuinCe/data/Dataset/DataReduction/UnderwayAtmosphericPco2Reducer.java
@@ -61,7 +61,6 @@ public class UnderwayAtmosphericPco2Reducer extends DataReducer {
 
       record.put("Sea Level Pressure", seaLevelPressure);
       record.put("pH₂O", calculator.pH2O);
-      record.put("xCO₂", co2InGas);
       record.put("pCO₂", calculator.pCO2);
       record.put("fCO₂", calculator.fCO2);
     } catch (Exception e) {
@@ -81,12 +80,9 @@ public class UnderwayAtmosphericPco2Reducer extends DataReducer {
         "pH₂O", "Atmosphere Water Vapour Pressure", "CPVPZZ01", "hPa", false));
 
       calculationParameters.add(new CalculationParameter(makeParameterId(2),
-        "xCO₂", "xCO₂ In Atmosphere", "XCO2DRAT", "μmol mol⁻¹", true));
-
-      calculationParameters.add(new CalculationParameter(makeParameterId(3),
         "pCO₂", "pCO₂ In Atmosphere", "ACO2XXXX", "μatm", true));
 
-      calculationParameters.add(new CalculationParameter(makeParameterId(4),
+      calculationParameters.add(new CalculationParameter(makeParameterId(3),
         "fCO₂", "fCO₂ In Atmosphere", "FCO2WTAT", "μatm", true));
     }
 

--- a/configuration/export_config.json
+++ b/configuration/export_config.json
@@ -69,6 +69,7 @@
       "AWMXRCORR": "Atmosphere True Moisture [umol mol-1]",
       "CAPAZZ01": "Atmospheric Pressure At Sea Level [hPa]",
       "XCO2DRAT": "xCO2 in atmosphere [umol mol-1]",
+      "XCO2DCMA": "xCO2 in atmosphere [umol mol-1]",
       "LPRES0EQ_equil": "LICOR Pressure (Equilibrator) [hPa]",
       "LPRES0EQ_atm": "LICOR Pressure (Atmosphere) [hPa]",
       "CTMPZZ01": "Atmospheric Temperature [degC]"
@@ -110,6 +111,7 @@
       "AWMXRCORR": "Atmosphere True Moisture [umol mol-1]",
       "CAPAZZ01": "Atmospheric Pressure At Sea Level [hPa]",
       "XCO2DRAT": "xCO2 in atmosphere [umol mol-1]",
+      "XCO2DCMA": "xCO2 in atmosphere [umol mol-1]",
       "LPRES0EQ_equil": "LICOR Pressure (Equilibrator) [hPa]",
       "LPRES0EQ_atm": "LICOR Pressure (Atmosphere) [hPa]",
       "CTMPZZ01": "Atmospheric Temperature [degC]"


### PR DESCRIPTION
Fix #2816
